### PR TITLE
Amber Dup Fix

### DIFF
--- a/scripts/BiomesOPlenty.zs
+++ b/scripts/BiomesOPlenty.zs
@@ -14,5 +14,9 @@ import mods.jei.JEI.removeAndHide as rh;# Custom recipes made by NillerMedDild
 # Honey Block -> Honey Drop
 	mods.forestry.Centrifuge.addRecipe([(<forestry:honey_drop> * 5) % 80, (<thermalfoundation:material:99> % 25), (<thermalfoundation:material:100> % 25)], <biomesoplenty:honey_block>, 100);
 	mods.thermalexpansion.Centrifuge.addRecipe([(<forestry:honey_drop>) * 5 % 80, <thermalfoundation:material:99> % 25, <thermalfoundation:material:100> % 25], <biomesoplenty:honey_block>, null, 2000);
+	
+	rh(<biomesoplenty:gem_block:7>);
+	rh(<biomesoplenty:gem_ore:7>);
+	rh(<biomesoplenty:gem:7>);
 
 	print("--- BiomesOPlenty.zs initialized ---");

--- a/scripts/NuclearCraft.zs
+++ b/scripts/NuclearCraft.zs
@@ -1,4 +1,5 @@
 import mods.jei.JEI.removeAndHide as rh;
+	print("--- loading NuclearCraft.zs ---");
 
 # Lithium Ingot Mekanism Compat
 	mods.mekanism.smelter.addRecipe(<ic2:dust:11>, <nuclearcraft:ingot:6>);

--- a/scripts/OreDict.zs
+++ b/scripts/OreDict.zs
@@ -133,7 +133,6 @@ import crafttweaker.item.IItemStack as IItemStack;
 	<ore:circuitBoard>.add(<immersiveengineering:material:27>);
 	
 # Amber Oredict
-	<ore:blockAmber>.add(<biomesoplenty:gem_block:7>);
 	<ore:blockAmber>.add(<thaumcraft:amber_block>);
 	<ore:blockAmber>.add(<thaumcraft:amber_brick>);
 


### PR DESCRIPTION
[ExpertSkyblock #518](https://github.com/NillerMedDild/Enigmatica2ExpertSkyblock/issues/518#issue-470832602)

Exists in Normal mode too.
There are 2 ambers; BoP and Thaumcraft