### PR TITLE
Ignore NBT data for Rotary Condensentrator

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -10988,7 +10988,7 @@
           "partialMatch:1": 1,
           "autoConsume:1": 0,
           "groupDetect:1": 0,
-          "ignoreNBT:1": 0,
+          "ignoreNBT:1": 1,
           "index:3": 0,
           "consume:1": 0,
           "requiredItems:9": {


### PR DESCRIPTION
Mekanism _Changing the state of matter!_ quest cannot be redeemed because Rotary Condensentrator has NBT data. This fixes it