### PR TITLE
Ignore NBT data for Turbine Valve

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -13552,7 +13552,7 @@
           "partialMatch:1": 1,
           "autoConsume:1": 0,
           "groupDetect:1": 0,
-          "ignoreNBT:1": 0,
+          "ignoreNBT:1": 1,
           "index:3": 0,
           "consume:1": 0,
           "requiredItems:9": {


### PR DESCRIPTION
Fix for Mekanism _Putting steam to use_ quest. Ignore Turbine Valve NBT data so it can be properly detected