### PR TITLE
Disable Actually Additions Easter Egg

### DIFF
--- a/config/actuallyadditions.cfg
+++ b/config/actuallyadditions.cfg
@@ -188,7 +188,7 @@ other {
     B:"Water Bowl Spilling"=true
 
     # 11?
-    I:"What is 11"=11
+    I:"What is 11"=69
 
     # The amount of ticks it takes for a worm to die. When at 0 ticks, it will not die.
     I:"Worm Death Time"=0


### PR DESCRIPTION
This (default!) config allows a player to gain potentially ANY item in the game (creative items, debug items, etc), for the measly cost of 150000 RF (unconfigurable). To disable it has to be any number except 11, I chose 69 because I'm a child at heart.